### PR TITLE
Correct the install requirement that breaks the whole program

### DIFF
--- a/gcastle/setup.py
+++ b/gcastle/setup.py
@@ -41,6 +41,6 @@ setuptools.setup(
         "matplotlib>=2.1.2",
         "networkx>=2.5",
         "torch>=1.4.0",
-        "tensorflow>=1.15.0",
+        "tensorflow~=1.15.0",
     ],
 )


### PR DESCRIPTION
This `setup.py` will install the latest version of tensorflow which doesn't include `tensorflow.contrib`. 
Should consider to use the `~=` specifier in the `requirement.txt`.