### PR TITLE
Save directed edges in web gui

### DIFF
--- a/gcastle/web/common/utils.py
+++ b/gcastle/web/common/utils.py
@@ -365,7 +365,7 @@ def save_gragh_edges(dag, file_name):
         tem_dag = dag.values
     else:
         tem_dag = dag
-    gragh = nx.from_numpy_array(tem_dag)
+    gragh = nx.from_numpy_array(tem_dag, create_using=nx.DiGraph)
     diagrams = list(gragh.edges)
 
     zero_col = np.where(~tem_dag.any(axis=0))[0]


### PR DESCRIPTION
Correctly save directed edges from the numpy array in the web GUI. This solves the problem of mismatching results as reported in issue #112.