### PR TITLE
Enhancement: Updated _simulate_linear_sem() function to support list of SEM types

### DIFF
--- a/gcastle/castle/datasets/simulator.py
+++ b/gcastle/castle/datasets/simulator.py
@@ -293,10 +293,10 @@ class IIDSimulation(object):
         X: np.ndarray
             [n, d] sample matrix, [d, d] if n=inf
         """
-        def _simulate_single_equation(X, w, scale, type):
+        def _simulate_single_equation(X, w, scale, sem_type_single):
             """
             Simulate a single equation in the SEM.
-            The noise type of this equation is determined by the 'type' parameter.
+            The noise type of this equation is determined by the 'sem_type_single' parameter.
             
             Parameters
             ----------
@@ -306,7 +306,7 @@ class IIDSimulation(object):
                 [num of parents] array representing the weights of parent variables.
             scale: float
                 Scale parameter for the noise distribution in the SEM.
-            type: str
+            sem_type_single: str
                 The type of noise to use for this variable. Can be 'gauss', 'exp', 'gumbel', 'uniform', 'logistic'.
         
             Returns
@@ -314,19 +314,19 @@ class IIDSimulation(object):
             x: np.ndarray
                 [n] array representing the values of the simulated variable.
             """
-            if type == 'gauss':
+            if sem_type_single == 'gauss':
                 z = np.random.normal(scale=scale, size=n)
                 x = X @ w + z
-            elif type == 'exp':
+            elif sem_type_single == 'exp':
                 z = np.random.exponential(scale=scale, size=n)
                 x = X @ w + z
-            elif type == 'gumbel':
+            elif sem_type_single == 'gumbel':
                 z = np.random.gumbel(scale=scale, size=n)
                 x = X @ w + z
-            elif type == 'uniform':
+            elif sem_type_single == 'uniform':
                 z = np.random.uniform(low=-scale, high=scale, size=n)
                 x = X @ w + z
-            elif type == 'logistic':
+            elif sem_type_single == 'logistic':
                 x = np.random.binomial(1, sigmoid(X @ w)) * 1.0
             else:
                 raise ValueError('Unknown sem type. In a linear model, \

--- a/gcastle/castle/datasets/simulator.py
+++ b/gcastle/castle/datasets/simulator.py
@@ -293,8 +293,27 @@ class IIDSimulation(object):
         X: np.ndarray
             [n, d] sample matrix, [d, d] if n=inf
         """
-        def _simulate_single_equation(X, w, scale, type=None):
-            """X: [n, num of parents], w: [num of parents], x: [n]"""
+        def _simulate_single_equation(X, w, scale, type):
+            """
+            Simulate a single equation in the SEM.
+            The noise type of this equation is determined by the 'type' parameter.
+            
+            Parameters
+            ----------
+            X: np.ndarray
+                [n, num of parents] matrix representing the values of parent variables.
+            w: np.ndarray
+                [num of parents] array representing the weights of parent variables.
+            scale: float
+                Scale parameter for the noise distribution in the SEM.
+            type: str
+                The type of noise to use for this variable. Can be 'gauss', 'exp', 'gumbel', 'uniform', 'logistic'.
+        
+            Returns
+            -------
+            x: np.ndarray
+                [n] array representing the values of the simulated variable.
+            """
             if type == 'gauss':
                 z = np.random.normal(scale=scale, size=n)
                 x = X @ w + z

--- a/gcastle/castle/datasets/simulator.py
+++ b/gcastle/castle/datasets/simulator.py
@@ -362,10 +362,10 @@ class IIDSimulation(object):
         elif isinstance(sem_type, list):
             # If it's a list, check if the length is equal to d
             if len(sem_type) != d:
-                raise ValueError(f"List size should be equal to {d}")
+                raise ValueError(f"The length of sem_type needs to be equal to {d} (the number of variables).")
             # ensure all elements in the list are strings
             if not all(isinstance(i, str) for i in sem_type):
-                raise ValueError("All elements in the list should be strings")
+                raise ValueError("All elements in the sem_type list must be strings.")
         else:
             raise TypeError("sem_type should be either a string or a list of strings")
 

--- a/gcastle/castle/datasets/simulator.py
+++ b/gcastle/castle/datasets/simulator.py
@@ -336,12 +336,12 @@ class IIDSimulation(object):
 
         # check if sem_type is a single string
         if isinstance(sem_type, str):
-            # If it is, make it a list of size n with the same value
-            sem_type = [sem_type] * n
+            # If it is, make it a list of size d with the same value
+            sem_type = [sem_type] * d
         elif isinstance(sem_type, list):
-            # If it's a list, check if the length is equal to n
-            if len(sem_type) != n:
-                raise ValueError(f"List size should be equal to {n}")
+            # If it's a list, check if the length is equal to d
+            if len(sem_type) != d:
+                raise ValueError(f"List size should be equal to {d}")
             # ensure all elements in the list are strings
             if not all(isinstance(i, str) for i in sem_type):
                 raise ValueError("All elements in the list should be strings")

--- a/gcastle/castle/datasets/simulator.py
+++ b/gcastle/castle/datasets/simulator.py
@@ -272,7 +272,7 @@ class IIDSimulation(object):
     @staticmethod
     def _simulate_linear_sem(W, n, sem_type, noise_scale):
         """
-        Simulate samples from linear SEM with specified type of noise.
+        Simulate samples from linear SEM with specified type(s) of noise.
         For uniform, noise z ~ uniform(-a, a), where a = noise_scale.
 
         Parameters
@@ -281,8 +281,10 @@ class IIDSimulation(object):
             [d, d] weighted adj matrix of DAG.
         n: int
             Number of samples, n=inf mimics population risk.
-        sem_type: str 
-            gauss, exp, gumbel, uniform, logistic.
+        sem_type: str or list of str
+            If str, all variables follow this noise type, e.g., 'gauss', 'exp', 'gumbel', 'uniform', 'logistic'.
+            If list of str, the ith noise variable follows the ith type in the list. 
+            The length of the list should be equal to the number of variables (i.e., d).
         noise_scale: float 
             Scale parameter of noise distribution in linear SEM.
         


### PR DESCRIPTION
This PR introduces an enhancement to the `_simulate_linear_sem()` function in the simulator.py file. The changes now allow the function to accept both a single string or a list of strings for the `sem_type` parameter, providing users with the flexibility to define different SEM types for each variable in the model.

Notably, these changes are backward compatible. Users who wish to continue using a single string for `sem_type` can do so without any disruption. The single string will still be interpreted as the SEM type for all variables, as in the previous version.

Changes made in this PR include:

1. Updated the `sem_type` parameter handling in the `_simulate_linear_sem()` function to allow for a list of SEM types as well as a single string.
2. Enhanced the `_simulate_single_equation()` method to generate variable noise according to the specified `sem_type_single`.
3. Updated the docstrings for both `_simulate_linear_sem()` and `_simulate_single_equation()` to reflect these changes.
4. Added robust error checking to ensure that the `sem_type` parameter is correctly formatted, either as a string or a list of strings of appropriate length.

These updates have been thoroughly tested to ensure correct and expected behavior.