### PR TITLE
Update evaluation.py

### DIFF
--- a/gcastle/castle/metrics/evaluation.py
+++ b/gcastle/castle/metrics/evaluation.py
@@ -120,11 +120,11 @@ class MetricsDAG(object):
         d = B_true.shape[0]
         
         # linear index of nonzeros
-        pred_und = np.flatnonzero(B_est == -1)
+        pred_und = np.concatenate([np.flatnonzero(B_est == -1), np.flatnonzero(B_est.T == -1)])
         pred = np.flatnonzero(B_est == 1)
         cond = np.flatnonzero(B_true)
         cond_reversed = np.flatnonzero(B_true.T)
-        cond_skeleton = np.concatenate([cond, cond_reversed])
+        cond_skeleton = np.unique(np.concatenate([cond, cond_reversed]))
         # true pos
         true_pos = np.intersect1d(pred, cond, assume_unique=True)
         # treat undirected edge favorably


### PR DESCRIPTION
Fixes issue with the tpr metric when undirected edges are present. 
Previously the TPR and recall metrics were inconsistent even though the listed computations in the comments are the same.
The TPR is computed by concatenating two arrays: one with non-zero indices in the true matrix and one with the non-zero values in the transpose (to handle undirected edges which are represented by one -1 and one 0 in the matrix). This concatenation duplicated some indices which gave incorrect results. Also, predicted undirected edges must be counted twice (once more for the transpose matrix).

Closes issue #155.