### PR TITLE
Enhance GOLEM Consistency with Notears: Fix Docstring for B_result and Introduce self.weight_causal_matrix

### DIFF
--- a/gcastle/castle/algorithms/gradient/notears/torch/golem.py
+++ b/gcastle/castle/algorithms/gradient/notears/torch/golem.py
@@ -189,8 +189,8 @@ class GOLEM(BaseLearner):
         ------
         B_result: np.ndarray
             [d, d] estimated binary matrix (with thresholding).
-        W_result: np.ndarray
-            [d, d] estimated weighted matrix.
+		W_result: np.ndarray
+			[d, d] estimated weighted matrix.
         
         Hyperparameters
         ---------------


### PR DESCRIPTION
1. Fixed the docstring:

- Clarified that B_result is the thresholded binary causal matrix.
- Added W_result to represent the learned weighted causal matrix.

2. Introduced self.weight_causal_matrix:

- This ensures that both the binary and weighted causal matrices are accessible, making the implementation more consistent with Notears.

3. Refactored _golem():

- Now returns both B_result (binary) and W_result (weighted).
- Updated the learn() method to store both matrices.

4. Improved Logging and Documentation:

- Updated docstrings to match the new changes and make old docstrings more accurate.