### PR TITLE
fix some comment examples

### DIFF
--- a/gcastle/castle/algorithms/ges/ges.py
+++ b/gcastle/castle/algorithms/ges/ges.py
@@ -50,6 +50,7 @@ class GES(BaseLearner):
     >>> from castle.common import GraphDAG
     >>> from castle.metrics import MetricsDAG
     >>> from castle.datasets import load_dataset
+    >>> from castle.algorithms.ges.ges import GES
 
     >>> X, true_dag, _ = load_dataset(name='IID_Test')
     >>> algo = GES()

--- a/gcastle/castle/algorithms/gradient/gae/torch/gae.py
+++ b/gcastle/castle/algorithms/gradient/gae/torch/gae.py
@@ -92,6 +92,28 @@ class GAE(BaseLearner):
         For single-device modules, ``device_ids`` can be int or str,
         e.g. 0 or '0', For multi-device modules, ``device_ids`` must be str,
         format like '0, 1'.
+    Examples
+    --------
+    >>> from castle.common import GraphDAG
+    >>> from castle.metrics import MetricsDAG
+    >>> from castle.datasets import DAG, IIDSimulation
+    >>> from castle.algorithms import GAE
+
+
+    >>> # simulate data for graph-auto-encoder
+    >>> weighted_random_dag = DAG.erdos_renyi(n_nodes=10, n_edges=20, weight_range=(0.5, 2.0), seed=1)
+    >>> dataset = IIDSimulation(W=weighted_random_dag, n=2000, method='linear', sem_type='gauss')
+    >>> true_dag, X = dataset.B, dataset.X
+
+    >>> ga = GAE(input_dim=10)
+    >>> ga.learn(X)
+
+    >>> # plot est_dag and true_dag
+    >>> GraphDAG(ga.causal_matrix, true_dag)
+
+    >>> # calculate accuracy
+    >>> met = MetricsDAG(ga.causal_matrix, true_dag)
+    >>> print(met.metrics)
     """
 
     def __init__(self,

--- a/gcastle/castle/algorithms/gradient/gran_dag/torch/gran_dag.py
+++ b/gcastle/castle/algorithms/gradient/gran_dag/torch/gran_dag.py
@@ -178,7 +178,11 @@ class GraNDAG(BaseLearner):
     Examples
     --------
         Load data
-    >>> from castle.datasets import load_dataset
+    >>> from castle.common import GraphDAG
+    >>> from castle.metrics import MetricsDAG
+    >>> from castle.datasets import DAG, IIDSimulation
+    >>> from castle.algorithms import GraNDAG
+    
     >>> data, true_dag, _ = load_dataset('IID_Test')
 
     >>> gnd = GraNDAG(input_dim=data.shape[1])

--- a/gcastle/castle/algorithms/pc/pc.py
+++ b/gcastle/castle/algorithms/pc/pc.py
@@ -59,6 +59,7 @@ class PC(BaseLearner):
     >>> from castle.common import GraphDAG
     >>> from castle.metrics import MetricsDAG
     >>> from castle.datasets import load_dataset
+    >>> from castle.algorithms import PC
 
     >>> X, true_dag, _ = load_dataset(name='IID_Test')
     >>> pc = PC(variant='stable')


### PR DESCRIPTION
I found that the commented examples of some methods are incomplete and don't work if you try to use them. I’ve updated the issues I found and added an example for the GAE algorithm to standardize the method descriptions.